### PR TITLE
Perapihan Tampilan Untuk v1.1.18

### DIFF
--- a/src/components/ApplicationForm/FourthStep.vue
+++ b/src/components/ApplicationForm/FourthStep.vue
@@ -30,7 +30,7 @@
             >
               <v-label class="title"><b>{{ $t('label.applicant_letter_number_upload') }}</b> <i class="text-small-first-step">{{ $t('label.must_fill') }}</i></v-label>
               <br>
-              <v-row>
+              <v-row class="mt-1">
                 <v-col sm="12" md="3">
                   <img v-if="!isUpload" height="100" src="../../static/upload_no_dokumen.svg">
                   <img v-if="isUpload" height="100" src="../../static/upload_dokumen.svg">
@@ -41,7 +41,7 @@
                     <v-label v-if="isUpload">{{ selectedFileName }}</v-label>
                   </v-row>
                   <br>
-                  <v-row class="mr-1 ml-1">
+                  <v-row class="mr-1 ml-1 mt-1">
                     <input
                       ref="uploader"
                       type="file"

--- a/src/components/ApplicationForm/FourthStep.vue
+++ b/src/components/ApplicationForm/FourthStep.vue
@@ -9,6 +9,7 @@
       <v-form
         ref="form"
         lazy-validation
+        class="mt-5"
       >
         <v-row>
           <v-col cols="12" sm="12" md="6">

--- a/src/styles/scss/custom/_landingPage.scss
+++ b/src/styles/scss/custom/_landingPage.scss
@@ -8,10 +8,19 @@
   padding: 50px 20px;
 }
 .header-landing-page {
-  padding: 45px;
-  margin-left: 100px;
-  margin-right: 100px;
-  margin-top: -30px;
+  padding: 66px;
+  margin-left: 80px;
+  margin-right: 80px;
+  margin-top: -25px;
+  margin-bottom: 10px;
+}
+.margin-top-15 {
+  margin-top: 15px;
+}
+.shadow-box {
+  box-shadow: 0px 0px 15px 5px #d8d8d8;
+  border-radius: 10px;
+  margin: 5px;
 }
 .title-page-landing-page {
   padding: 5px 20px;

--- a/src/views/acceptanceReport/index.vue
+++ b/src/views/acceptanceReport/index.vue
@@ -160,7 +160,7 @@
               </v-form>
             </ValidationObserver>
           </div>
-          <div v-if="showVerificationForm && acceptanceLogisticFormShow"><!-- Form Acceptance Logistic Report -->
+          <div v-if="showVerificationForm && acceptanceLogisticFormShow" class="mt-5"><!-- Form Acceptance Logistic Report -->
             <ValidationObserver ref="observer3">
               <div id="form-body">
                 <div><!-- Informasi Penerima Barang -->
@@ -321,7 +321,7 @@
                       </v-card>
                     </v-dialog>
                   </v-row>
-                  <v-row>
+                  <v-row class="mt-5">
                     <v-col sm="12" md="8" class="left-side">
                       <v-label><b>{{ $t('label.acceptance_report.officer_fullname') }}</b> <i class="text-small-first-step">{{ $t('label.must_fill') }}</i></v-label>
                       <div class="body-text">
@@ -410,7 +410,7 @@
                                       <v-col
                                         cols="12"
                                         sm="6"
-                                        md="4"
+                                        md="3"
                                       >
                                         <v-text-field
                                           v-model="editedItem.qty_ok"
@@ -424,7 +424,7 @@
                                       <v-col
                                         cols="12"
                                         sm="6"
-                                        md="4"
+                                        md="3"
                                       >
                                         <v-text-field
                                           v-model="editedItem.qty_nok"
@@ -438,7 +438,7 @@
                                       <v-col
                                         cols="12"
                                         sm="6"
-                                        md="4"
+                                        md="6"
                                       >
                                         <v-select
                                           v-model="editedItem.quality"
@@ -476,7 +476,7 @@
                       <v-alert type="error">{{ $t('label.acceptance_report.error.item_proof') }}</v-alert>
                     </v-col>
                   </v-row>
-                  <v-row>
+                  <v-row class="mt-5">
                     <v-col sm="12" md="8" class="left-side">
                       <v-label><b>{{ $t('label.acceptance_report.bast_proof') }}</b> <i class="text-small-first-step">{{ $t('label.must_fill') }}</i></v-label>
                       <div class="body-text">
@@ -563,7 +563,7 @@
                       </v-card>
                     </v-dialog>
                   </v-row>
-                  <v-row>
+                  <v-row class="mt-5">
                     <v-col sm="12" md="8" class="left-side">
                       <v-label><b>Foto Barang yang Diterima</b> <i class="text-small-first-step">{{ $t('label.must_fill') }}</i></v-label>
                       <div class="body-text">
@@ -651,14 +651,14 @@
                       </v-card>
                     </v-dialog>
                   </v-row>
-                  <v-row>
+                  <v-row class="mt-5">
                     <v-col sm="12" md="8" class="left-side">
                       <v-label><b>{{ $t('label.acceptance_report.note') }}</b></v-label>
                       <v-textarea
                         v-model="recipient.note"
                         outlined
                         solo-inverted
-                        placeholder="Tambahkan catatan lainnya..."
+                        placeholder="Tambahkan catatan lainnya terhadap barang yang tidak sesuai..."
                       />
                     </v-col>
                   </v-row>
@@ -1043,6 +1043,21 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
+ .header-landing-page {
+   padding: 66px;
+   margin-left: 80px;
+   margin-right: 80px;
+   margin-top: -25px;
+   margin-bottom: 10px;
+ }
+ .margin-top-15 {
+   margin-top: 15px;
+ }
+ .shadow-box {
+   box-shadow: 0px 0px 15px 5px #d8d8d8;
+   border-radius: 10px;
+   margin: 5px;
+ }
  .main-card-landing-page {
    padding: 50px;
  }

--- a/src/views/acceptanceReport/index.vue
+++ b/src/views/acceptanceReport/index.vue
@@ -1043,21 +1043,6 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
- .header-landing-page {
-   padding: 66px;
-   margin-left: 80px;
-   margin-right: 80px;
-   margin-top: -25px;
-   margin-bottom: 10px;
- }
- .margin-top-15 {
-   margin-top: 15px;
- }
- .shadow-box {
-   box-shadow: 0px 0px 15px 5px #d8d8d8;
-   border-radius: 10px;
-   margin: 5px;
- }
  .main-card-landing-page {
    padding: 50px;
  }

--- a/src/views/landingPage/index.vue
+++ b/src/views/landingPage/index.vue
@@ -301,21 +301,3 @@ export default {
   }
 }
 </script>
-
-<style lang="scss" scope>
-  .header-landing-page {
-    padding: 66px;
-    margin-left: 80px;
-    margin-right: 80px;
-    margin-top: -25px;
-    margin-bottom: 10px;
-  }
-  .margin-top-15 {
-    margin-top: 15px;
-  }
-  .shadow-box {
-    box-shadow: 0px 0px 15px 5px #d8d8d8;
-    border-radius: 10px;
-    margin: 5px;
-  }
-</style>

--- a/src/views/landingPage/index.vue
+++ b/src/views/landingPage/index.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="background-landing-page">
     <div class="full-landing-page">
+      <!-- <div class="header-landing-page"> -->
       <div class="header-landing-page">
         <v-row align="center">
-          <v-col cols="12" md="9" xs="12">
+          <v-col>
             <v-row>
               <img height="40" src="../../static/logistik_logo_lingkar.svg">
               <div class="title-page-landing-page">{{ $t('label.logistics_medical_device') }}</div>
@@ -302,6 +303,13 @@ export default {
 </script>
 
 <style lang="scss" scope>
+  .header-landing-page {
+    padding: 66px;
+    margin-left: 80px;
+    margin-right: 80px;
+    margin-top: -25px;
+    margin-bottom: 10px;
+  }
   .margin-top-15 {
     margin-top: 15px;
   }

--- a/src/views/landingPage/index.vue
+++ b/src/views/landingPage/index.vue
@@ -22,10 +22,10 @@
         <v-row>
           <v-col cols="10">
             <v-row>
-              <v-col class="margin-left-20" cols="2">
+              <v-col class="margin-left-20 margin-top-15" cols="2">
                 <img height="40" src="../../static/logistik_logo_lingkar.svg">
               </v-col>
-              <v-col cols="10">
+              <v-col cols="6">
                 <div class="title-page-landing-page-mobile margin-left-title-mobile-landing-page">
                   {{ $t('label.logistics_medical_device') }}
                 </div>
@@ -300,3 +300,9 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scope>
+  .margin-top-15 {
+    margin-top: 15px;
+  }
+</style>

--- a/src/views/landingPage/index.vue
+++ b/src/views/landingPage/index.vue
@@ -104,7 +104,7 @@
         </div>
         <div>
           <v-row>
-            <v-col>
+            <v-col class="shadow-box">
               <img src="../../static/logistic_acceptance_report.png" width="100%">
               <div class="font-product-sans-landing-page card-feature-landing-page mb-5 font-weight-bold text-center">
                 {{ $t('label.logistic_acceptance_report_title') }}
@@ -116,7 +116,7 @@
                 </v-btn>
               </div>
             </v-col>
-            <v-col>
+            <v-col class="shadow-box">
               <img src="../../static/logistic_usability_report.png" width="100%">
               <div class="font-product-sans-landing-page card-feature-landing-page mb-5 font-weight-bold text-center">
                 {{ $t('label.logistic_usability_report_title') }}
@@ -128,7 +128,7 @@
                 </v-btn>
               </div>
             </v-col>
-            <v-col>
+            <v-col class="shadow-box">
               <img src="../../static/tracking_logistik_1.png" width="100%">
               <div class="font-product-sans-landing-page card-feature-landing-page mb-5 font-weight-bold text-center">
                 {{ $t('label.logistic_tracking_title') }}
@@ -304,5 +304,10 @@ export default {
 <style lang="scss" scope>
   .margin-top-15 {
     margin-top: 15px;
+  }
+  .shadow-box {
+    box-shadow: 0px 0px 15px 5px #d8d8d8;
+    border-radius: 10px;
+    margin: 5px;
   }
 </style>

--- a/src/views/tracking/index.vue
+++ b/src/views/tracking/index.vue
@@ -470,6 +470,21 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
+  .header-landing-page {
+    padding: 66px;
+    margin-left: 80px;
+    margin-right: 80px;
+    margin-top: -25px;
+    margin-bottom: 10px;
+  }
+  .margin-top-15 {
+    margin-top: 15px;
+  }
+  .shadow-box {
+    box-shadow: 0px 0px 15px 5px #d8d8d8;
+    border-radius: 10px;
+    margin: 5px;
+  }
  .main-card-landing-page {
    padding: 50px;
  }

--- a/src/views/tracking/index.vue
+++ b/src/views/tracking/index.vue
@@ -470,21 +470,6 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-  .header-landing-page {
-    padding: 66px;
-    margin-left: 80px;
-    margin-right: 80px;
-    margin-top: -25px;
-    margin-bottom: 10px;
-  }
-  .margin-top-15 {
-    margin-top: 15px;
-  }
-  .shadow-box {
-    box-shadow: 0px 0px 15px 5px #d8d8d8;
-    border-radius: 10px;
-    margin: 5px;
-  }
  .main-card-landing-page {
    padding: 50px;
  }


### PR DESCRIPTION
1. Untuk popupnya sedikit diperbesar dengan harapan labelnya tertulis jelas "Kualitas/ Mutu Barang yang diterima". Terlampir pada gambar https://trello-attachments.s3.amazonaws.com/5e7cc257ce91964fe85236ce/5ffd1dddf57da95625cd5c5b/fbea69cae9c596768837a64518afc7f1/image.png
2. Untuk poin kedua belum diubah labelnya menjadi "Tambahkan catatan lainnya terhadap barang yang tidak sesuai", mungkin bisa ditambahin di hint/ placeholdernya. Terlampir pada gambar https://trello-attachments.s3.amazonaws.com/5e7cc257ce91964fe85236ce/5ffd1dddf57da95625cd5c5b/ea14f087a4b4c7f72f4b74010f0a9ca6/image.png
3. Step to reproduce: Pengguna memilih instansi lainnya ataupun instansi rumah sakit, puskesmas atau klinik
Kondisi existing: Tampilan pas step 4 sudah tepat, namun tampilan menjadi tumpang tindih
Kondisi yang diharapkan: Jika sudah memilih instansi lainnya sudah tepat secara fungsional tidak menampilkan data isian (Jumlah Pasien COVID-19 yang ditangani, Jumlah Ruang Isolasi, Jumlah tempat tidur, Jumlah Tenaga Kesehatan yang menangani pasien COVID-19) namun tampilannya seharusnya tidak tumpang tindih
Terlampir:
[1] https://trello-attachments.s3.amazonaws.com/5e7cc257ce91964fe85236ce/5fe297de58abc84ac2a65f2f/6176664a0e17e8e781e31f2a73f499cc/image.png
[2] https://trello-attachments.s3.amazonaws.com/5fe297de58abc84ac2a65f2f/1200x689/b1ea889dc083b58bfb8c24974ed5144c/image.png
4. Tampilan pada landing page permohonan publik berubah, terlampir tampilannya (https://trello-attachments.s3.amazonaws.com/5ff7d8a5eff4b832004253fe/1200x524/0e467bf1f4dab6f3e278cfe275b748c7/image.png)
5. Tampilan header untuk bagian mobile untuk posisi logo dan logo panduan bergeser
6. Tampilan untuk bagian section pelaporan dan tracking logistik dibuat ada borderingnya dengan ada shadow sedikit dibelakangnya
7. Poin 2 dan 3 terlampir yaa disini (https://trello-attachments.s3.amazonaws.com/5ff7d8a5eff4b832004253fe/292x2134/c91f64dbf6bd89849b5927e305e8a1c7/image.png)