### PR TITLE
bugfix Alasan Ditolak tahap rekomendasi tidak muncul

### DIFF
--- a/src/views/pengajuanLogistik/reasonReject.vue
+++ b/src/views/pengajuanLogistik/reasonReject.vue
@@ -26,8 +26,8 @@
         <v-col>
           <span class="sub-title-reject-reason">{{ $t('label.reason_reject') }}</span>
           <br>
-          <span v-if="item.applicant ? item.applicant.note !== null : null" class="grey--text">{{ item.applicant ? item.applicant.note : '-' }}</span>
-          <span v-else class="grey--text">{{ item.applicant ? item.applicant.approval_note : '-' }}</span>
+          <span v-if="item.applicant.approval_status == 'Permohonan Ditolak'" class="grey--text">{{ item.applicant.approval_note }}</span>
+          <span v-else class="grey--text">{{ item.applicant.note }}</span>
         </v-col>
       </div>
 


### PR DESCRIPTION
[Hotfix] Alasan penolakan tidak muncul pada detail permohonan pada menu Ditolak (asumsi awal dari penolakan pada Rekomendasi)

https://trello.com/c/ZGSkPQBJ/367-hotfix-alasan-penolakan-tidak-muncul-pada-detail-permohonan-pada-menu-ditolak-asumsi-awal-dari-penolakan-pada-rekomendasi

Step to reproduce
-----------------
- PIC membuka permohonan yang berada pada menu Rekomendasi
- PIC melakukan penolakan terhadap permohonan tersebut dengan menyertakan alasan penolakannya