### PR TITLE
Granting access to Kota/Kab user

### DIFF
--- a/src/router/modules/pengajuanLogistik.js
+++ b/src/router/modules/pengajuanLogistik.js
@@ -7,7 +7,7 @@ const pengajuanLogistik = {
   meta: {
     title: 'logistic_request_title',
     icon: 'medication',
-    roles: ['superadmin', 'dinkesprov']
+    roles: ['superadmin', 'dinkesprov', 'dinkeskota']
   },
   active: false,
   children: [
@@ -18,7 +18,7 @@ const pengajuanLogistik = {
       meta: {
         title: 'not_verified_title',
         noCache: true,
-        roles: ['superadmin', 'dinkesprov']
+        roles: ['superadmin', 'dinkesprov', 'dinkeskota']
       }
     },
     {
@@ -28,7 +28,7 @@ const pengajuanLogistik = {
       meta: {
         title: 'verified_title',
         noCache: true,
-        roles: ['superadmin', 'dinkesprov']
+        roles: ['superadmin', 'dinkesprov', 'dinkeskota']
       }
     },
     {
@@ -38,7 +38,7 @@ const pengajuanLogistik = {
       meta: {
         title: 'approved_title',
         noCache: true,
-        roles: ['superadmin', 'dinkesprov']
+        roles: ['superadmin', 'dinkesprov', 'dinkeskota']
       }
     },
     {
@@ -48,7 +48,7 @@ const pengajuanLogistik = {
       meta: {
         title: 'rejected_title',
         noCache: true,
-        roles: ['superadmin', 'dinkesprov']
+        roles: ['superadmin', 'dinkesprov', 'dinkeskota']
       }
     },
     {
@@ -59,7 +59,7 @@ const pengajuanLogistik = {
         title: 'applicant_medical_tools_list_title',
         icon: 'library_books',
         noCache: true,
-        roles: ['superadmin', 'dinkesprov']
+        roles: ['superadmin', 'dinkesprov', 'dinkeskota']
       }
     }
   ]

--- a/src/router/modules/reports.js
+++ b/src/router/modules/reports.js
@@ -7,7 +7,7 @@ const reports = {
   meta: {
     title: 'report',
     icon: 'fact_check',
-    roles: ['superadmin', 'dinkesprov']
+    roles: ['superadmin', 'dinkesprov', 'dinkeskota']
   },
   active: false,
   children: [
@@ -18,7 +18,7 @@ const reports = {
       meta: {
         title: 'goods_receipt_report',
         noCache: true,
-        roles: ['superadmin', 'dinkesprov']
+        roles: ['superadmin', 'dinkesprov', 'dinkeskota']
       }
     },
     {
@@ -28,7 +28,7 @@ const reports = {
       meta: {
         title: 'goods_use_report',
         noCache: true,
-        roles: ['superadmin', 'dinkesprov']
+        roles: ['superadmin', 'dinkesprov', 'dinkeskota']
       }
     },
     {
@@ -39,7 +39,7 @@ const reports = {
         title: 'goods_receipt_report',
         icon: 'library_books',
         noCache: true,
-        roles: ['superadmin', 'dinkesprov']
+        roles: ['superadmin', 'dinkesprov', 'dinkeskota']
       }
     }
   ]

--- a/src/store/modules/user/actions.js
+++ b/src/store/modules/user/actions.js
@@ -21,10 +21,11 @@ export default {
   getInfo({ commit, state }) {
     return new Promise((resolve, reject) => {
       doPostUpdate('/api/v1/users/me', 'GET').then((response) => {
-        const { roles, name, code_district_city, phase } = response.data
+        const { roles, name, code_district_city, name_district_city, phase } = response.data
         const role = [roles]
         commit('SET_ROLES', role)
         commit('SET_DISTRICT', code_district_city)
+        commit('SET_DISTRICT_NAME', name_district_city)
         commit('SET_FULLNAME', name)
         commit('SET_USER', response.data)
         commit('SET_PHASE', phase)

--- a/src/store/modules/user/index.js
+++ b/src/store/modules/user/index.js
@@ -10,7 +10,8 @@ const state = {
   roles: [],
   district_user: '',
   fullname: '',
-  phase: ''
+  phase: '',
+  district_name: ''
 }
 
 export default {

--- a/src/store/modules/user/mutations.js
+++ b/src/store/modules/user/mutations.js
@@ -11,6 +11,9 @@ export default {
   SET_DISTRICT: (state, district) => {
     state.district_user = district
   },
+  SET_DISTRICT_NAME: (state, districtName) => {
+    state.district_name = districtName
+  },
   SET_FULLNAME: (state, fullname) => {
     state.fullname = fullname
   },

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -154,7 +154,7 @@
                       <applicant-instance-chart />
                     </v-col>
                   </v-row>
-                  <v-row>
+                  <v-row v-if="roles[0] !== 'dinkeskota'">
                     <v-col cols="12" sm="12" md="12">
                       <statistic-applicant-chart />
                     </v-col>
@@ -170,7 +170,7 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 import EventBus from '@/utils/eventBus'
 import FormatingNumber from '../../helpers/formattingNumber'
 
@@ -188,6 +188,9 @@ export default {
   computed: {
     ...mapGetters('logistics', [
       'dataLogisticRequestSummary'
+    ]),
+    ...mapState('user', [
+      'roles'
     ])
   },
   async mounted() {

--- a/src/views/pengajuanLogistik/list.vue
+++ b/src/views/pengajuanLogistik/list.vue
@@ -58,7 +58,12 @@
           </v-col>
           <v-col cols="12" sm="2">
             <v-label class="title">{{ $t('label.city_district') }}</v-label>
-            <select-area-district-city :on-select-district-city="onSelectDistrictCity" />
+            <select-area-district-city
+              :disabled-district="disabledDistrict"
+              :district-city="districtCity"
+              :city-district.sync="districtCity"
+              :on-select-district-city="onSelectDistrictCity"
+            />
           </v-col>
           <v-col cols="12" sm="3">
             <v-label class="title">{{ $t('label.instance_type') }}</v-label>
@@ -226,7 +231,7 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 import FileSaver from 'file-saver'
 import EventBus from '@/utils/eventBus'
 import completenessDetail from './completenessDetail'
@@ -323,7 +328,9 @@ export default {
       isVerified: false,
       isApproved: false,
       showcompletenessDetail: false,
-      showreferenceDetail: false
+      showreferenceDetail: false,
+      disabledDistrict: false,
+      districtCity: null
     }
   },
   computed: {
@@ -334,6 +341,11 @@ export default {
     ]),
     ...mapGetters('faskesType', [
       'faskesTypeList'
+    ]),
+    ...mapState('user', [
+      'roles',
+      'district_user', // district code
+      'district_name'
     ])
   },
   async created() {
@@ -358,6 +370,7 @@ export default {
     EventBus.$on('hideReferenceDetail', (value) => {
       this.showreferenceDetail = false
     })
+    if (this.roles[0] === 'dinkeskota') this.lockDistrictFilter()
   },
   methods: {
     async changeDate(value) {
@@ -402,6 +415,14 @@ export default {
     referenceDetail(data) {
       this.$refs.referenceDetailForm.setData(data.id, data)
       this.showreferenceDetail = true
+    },
+    lockDistrictFilter() {
+      this.disabledDistrict = true
+      this.districtCity = {
+        kemendagri_kabupaten_kode: this.district_user,
+        kemendagri_kabupaten_nama: this.district_name
+      }
+      this.onSelectDistrictCity(this.districtCity)
     }
   }
 }


### PR DESCRIPTION
### Overview
1. Grant Kota/Kab users to access `Pengajuan` and `Pelaporan` menu
2. Hide bar chart in `Dashboard` menu for Kota/Kab users
3. Auto fill district filter for Kota/Kab users

### Task
https://trello.com/c/htFbcKuP/404-2510-akses-dinkes-kab-kota-dinkes-dapat-login-dan-masuk-ke-halaman-admin
https://trello.com/c/ITvfeGid/405-2511-akses-dinkes-kab-kota-menampilkan-menu-dashboard-permohonan-pengajuan-dan-pelaporan-pada-saat-dinkes-sudah-login
https://trello.com/c/oanS45rz/406-2512-akses-dinkes-kab-kota-dinkes-dapat-melihat-dashboard-berdasarkan-kota-kabupaten-user-login
https://trello.com/c/Y9OwwKZv/407-2513-akses-dinkes-kab-kota-dinkes-dapat-melihat-pengajuan-berdasarkan-tahapannya-yang-difilter-berdasarkan-kota-tempat-dinkes-ko

### Todo
1. Add param `district` to `Dashboard` and `Pelaporan` for Kota/Kab users (still waiting from BE)

cc @Arif9878 @adrianpdm @maruf12 @adzharamrullah @Ibwedagama @bangunbagustapa @maulanayuseph @yoslie