### PR TITLE
Prevent double hit to API

### DIFF
--- a/src/views/pengajuanLogistik/list.vue
+++ b/src/views/pengajuanLogistik/list.vue
@@ -370,7 +370,8 @@ export default {
       this.isApproved = true
     }
     await this.$store.dispatch('faskesType/getListFaskesType')
-    this.roles[0] === 'dinkeskota' ? this.lockDistrictFilter() : this.getLogisticRequestList()
+    if (this.roles[0] === 'dinkeskota') this.lockDistrictFilter()
+    this.getLogisticRequestList()
     EventBus.$on('hideCompletenessDetail', (value) => {
       this.showcompletenessDetail = false
     })
@@ -428,7 +429,7 @@ export default {
         kemendagri_kabupaten_kode: this.district_user,
         kemendagri_kabupaten_nama: this.district_name
       }
-      this.onSelectDistrictCity(this.districtCity)
+      this.listQuery.city_code = this.districtCity.kemendagri_kabupaten_kode
     }
   }
 }

--- a/src/views/pengajuanLogistik/list.vue
+++ b/src/views/pengajuanLogistik/list.vue
@@ -370,14 +370,13 @@ export default {
       this.isApproved = true
     }
     await this.$store.dispatch('faskesType/getListFaskesType')
-    this.getLogisticRequestList()
+    this.roles[0] === 'dinkeskota' ? this.lockDistrictFilter() : this.getLogisticRequestList()
     EventBus.$on('hideCompletenessDetail', (value) => {
       this.showcompletenessDetail = false
     })
     EventBus.$on('hideReferenceDetail', (value) => {
       this.showreferenceDetail = false
     })
-    if (this.roles[0] === 'dinkeskota') this.lockDistrictFilter()
   },
   methods: {
     async changeDate(value) {


### PR DESCRIPTION
### Overview
Preventing double hit `/api/v1/logistic-request` when user kota/kab access `Pengajuan Logistik` menu

cc @Arif9878 @adrianpdm @maruf12 @adzharamrullah @Ibwedagama @bangunbagustapa @maulanayuseph @yoslie