### PR TITLE
Prevent double hit api on dashboard

### DIFF
--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -193,9 +193,6 @@ export default {
       'roles'
     ])
   },
-  async mounted() {
-    await this.getLogisticRequestSummary()
-  },
   methods: {
     async getLogisticRequestSummary() {
       await this.$store.dispatch('logistics/getLogisticRequestSummary', this.listQuery)


### PR DESCRIPTION
### Overview
Delete calling `getLogisticRequestSummary()` function in `dashboard/index.vue` to prevent double hit api