### PR TITLE
[Bug Hotfix] Logistic Request Date Filter Issue

### DIFF
--- a/src/views/pengajuanLogistik/list.vue
+++ b/src/views/pengajuanLogistik/list.vue
@@ -181,7 +181,7 @@
                   </td>
                   <td>{{ data.city.kemendagri_kabupaten_nama }}</td>
                   <td>{{ data.applicant.applicant_name }}</td>
-                  <td>{{ data.created_at === null ? $t('label.stripe') : $moment(data.created_at).format('D MMMM YYYY') }}</td>
+                  <td>{{ data.applicant.created_at === null ? $t('label.stripe') : $moment(data.applicant.created_at).format('D MMMM YYYY') }}</td>
                   <td v-if="isApproved" class="text-center">
                     <span v-if="data.applicant.approved_by" class="green--text">{{ data.applicant.approved_by.name }}</span>
                     <span v-else class="red--text">{{ 'Belum DiSetujui' }}</span>


### PR DESCRIPTION
## [Bug Hotfix] Tidak dapat melakukan filter tanggal sehingga ketika filter tanggal dilakukan data tidak muncul pada daftar permohonan

Permasalahan
- Ketika melakukan filter tanggal pengajuan, daftar permohonan yang muncul tidak sesuai dengan target filterisasi tanggalnya.

Solving:
- Isunya ditemukan bahwa untuk kolom Tanggal Pengajuan, masih menggunakan `created_at` dari table `agency`, sedangkan filterisasi menggunakan filterisasi tanggal dari table `applicant`
- Filterisasi memang harus berdasarkan tanggal created_at dari table `applicant`
- Sehingga solving terbaik adalah mengubah acuan variabel untuk tanggal pengajuan ke `data.applicant.created_at` 