### PR TITLE
Fix Logistic request pagination

### DIFF
--- a/src/components/DatePicker/dateDashboard.vue
+++ b/src/components/DatePicker/dateDashboard.vue
@@ -79,8 +79,8 @@ export default {
   data() {
     return {
       menu: false,
-      startDate: this.initialStartDate ? this.initialStartDate : '2020-01-01',
-      endDate: this.initialEndDate ? this.initialEndDate : this.$moment(Date.now()).format('YYYY-MM-DD'),
+      startDate: this.initialStartDate || '2020-01-01',
+      endDate: this.initialEndDate || this.$moment(Date.now()).format('YYYY-MM-DD'),
       dateFormatted: this.initialStartDate && this.initialEndDate
         ? `${this.$moment(this.initialStartDate).format('DD MMMM YYYY')} - ${this.$moment(this.initialEndDate).format('DD MMMM YYYY')}`
         : null,

--- a/src/components/DatePicker/dateDashboard.vue
+++ b/src/components/DatePicker/dateDashboard.vue
@@ -66,14 +66,24 @@ export default {
     rule: {
       type: String,
       default: ''
+    },
+    initialStartDate: {
+      type: String,
+      default: null
+    },
+    initialEndDate: {
+      type: String,
+      default: null
     }
   },
   data() {
     return {
       menu: false,
-      startDate: '2020-01-01',
-      endDate: this.$moment(Date.now()).format('YYYY-MM-DD'),
-      dateFormatted: null,
+      startDate: this.initialStartDate ? this.initialStartDate : '2020-01-01',
+      endDate: this.initialEndDate ? this.initialEndDate : this.$moment(Date.now()).format('YYYY-MM-DD'),
+      dateFormatted: this.initialStartDate && this.initialEndDate
+        ? `${this.$moment(this.initialStartDate).format('DD MMMM YYYY')} - ${this.$moment(this.initialEndDate).format('DD MMMM YYYY')}`
+        : null,
       currentDate: this.$moment(Date.now()).format('YYYY-MM-DD')
     }
   },

--- a/src/store/modules/faskesType/actions.js
+++ b/src/store/modules/faskesType/actions.js
@@ -1,11 +1,14 @@
 import { fetchList } from '@/api'
 
 export default {
-  async getListFaskesType({ commit }, params) {
+  async getListFaskesType({ state, commit }, params) {
     try {
-      const response = await fetchList('/api/v1/master-faskes-type', 'GET', params)
-      commit('SET_LIST_FASKES_TYPE', response.data)
-      return response
+      const { listFaskesType } = state
+      if (!Array.isArray(listFaskesType) || !listFaskesType.length) {
+        const response = await fetchList('/api/v1/master-faskes-type', 'GET', params)
+        commit('SET_LIST_FASKES_TYPE', response.data)
+      }
+      return state.listFaskesType
     } catch (error) {
       return error.response
     }

--- a/src/views/pengajuanLogistik/list.vue
+++ b/src/views/pengajuanLogistik/list.vue
@@ -398,6 +398,7 @@ export default {
     async changeDate(value) {
       this.listQuery.start_date = value.startDate
       this.listQuery.end_date = value.endDate
+      this.listQuery.page = 1
       this.$router.replace({
         query: {
           ...this.filterQuery(this.listQuery)
@@ -443,6 +444,7 @@ export default {
     },
     onSelectDistrictCity(value) {
       this.listQuery.city_code = value ? value.kemendagri_kabupaten_kode : ''
+      this.listQuery.page = 1
       this.$router.replace({
         query: {
           ...this.filterQuery(this.listQuery),

--- a/src/views/pengajuanLogistik/list.vue
+++ b/src/views/pengajuanLogistik/list.vue
@@ -220,9 +220,10 @@
     <pagination
       :total="totalListLogisticRequest"
       :total-data="totalDataLogisticRequest"
-      :page.sync="listQuery.page"
-      :limit.sync="listQuery.limit"
-      :on-next="onNext"
+      :page="listQuery.page"
+      :limit="listQuery.limit"
+      @update:page="onListQueryPageUpdated"
+      @update:limit="onListQueryLimitUpdated"
     />
     <completenessDetail
       ref="completenessDetailForm"
@@ -249,24 +250,31 @@ export default {
     referenceDetail
   },
   data() {
+    const faskesType = parseInt(this.$route.query?.faskes_type)
+    const isReference = parseInt(this.$route.query?.is_reference)
+    const completeness = parseInt(this.$route.query?.completeness)
+    const isUrgency = parseInt(this.$route.query?.is_urgency)
+    const finalizedBy = parseInt(this.$route.query?.finalized_by)
     return {
       sortOption: [
         { value: 'asc', label: 'A-Z' },
         { value: 'desc', label: 'Z-A' }
       ],
       listQuery: {
-        page: 1,
-        limit: 10,
-        sort: '',
-        city_code: '',
-        verification_status: '',
-        agency_name: '',
-        start_date: null,
-        end_date: null,
-        is_reference: null,
-        completeness: null,
-        is_urgency: null,
-        finalized_by: null
+        page: parseInt(this.$route.query?.page || 1),
+        limit: parseInt(this.$route.query?.limit || 10),
+        sort: this.$route.query?.sort || '',
+        city_code: this.$route.query?.city_code || '',
+        verification_status: this.$route.query?.verification_status || '',
+        agency_name: this.$route.query?.agency_name || '',
+        start_date: this.$route.query?.start_date || null,
+        end_date: this.$route.query?.end_date || null,
+        is_reference: Number.isNaN(isReference) ? null : isReference,
+        completeness: Number.isNaN(completeness) ? null : completeness,
+        is_urgency: Number.isNaN(isUrgency) ? null : isUrgency,
+        finalized_by: Number.isNaN(finalizedBy) ? null : finalizedBy,
+        faskes_type: Number.isNaN(faskesType) ? null : faskesType,
+        source_data: this.$route.query?.source_data || null
       },
       status: [
         {
@@ -329,7 +337,7 @@ export default {
         }
       ],
       date: null,
-      showFilter: false,
+      showFilter: true,
       isVerified: false,
       isApproved: false,
       isRejected: false,
@@ -378,12 +386,22 @@ export default {
     EventBus.$on('hideReferenceDetail', (value) => {
       this.showreferenceDetail = false
     })
+    if (this.$route.query?.city_code && this.$route.query?.city_name) {
+      this.districtCity = {
+        kemendagri_kabupaten_kode: this.$route.query?.city_code,
+        kemendagri_kabupaten_nama: this.$route.query?.city_name
+      }
+    }
   },
   methods: {
     async changeDate(value) {
       this.listQuery.start_date = value.startDate
       this.listQuery.end_date = value.endDate
-      await this.getLogisticRequestList()
+      this.$router.replace({
+        query: {
+          ...this.filterQuery(this.listQuery)
+        }
+      })
     },
     async getLogisticRequestList() {
       await this.$store.dispatch('logistics/getListLogisticRequest', this.listQuery)
@@ -395,17 +413,41 @@ export default {
     },
     async handleSearch() {
       this.listQuery.page = 1
-      await this.getLogisticRequestList()
+      this.$router.replace({
+        query: {
+          ...this.filterQuery(this.listQuery)
+        }
+      })
     },
-    async onNext() {
-      await this.getLogisticRequestList()
+    onListQueryPageUpdated(newPage) {
+      this.listQuery.page = newPage
+      this.$router.replace({
+        query: {
+          ...this.$route.query,
+          page: newPage
+        }
+      })
+    },
+    onListQueryLimitUpdated(newLimit) {
+      this.listQuery.limit = newLimit
+      this.$router.replace({
+        query: {
+          ...this.$route.query,
+          limit: newLimit
+        }
+      })
     },
     getTableRowNumbering(index) {
       return ((this.listQuery.page - 1) * this.listQuery.limit) + (index + 1)
     },
     onSelectDistrictCity(value) {
       this.listQuery.city_code = value ? value.kemendagri_kabupaten_kode : ''
-      this.handleSearch()
+      this.$router.replace({
+        query: {
+          ...this.filterQuery(this.listQuery),
+          city_name: value.kemendagri_kabupaten_nama
+        }
+      })
     },
     toDetail(data) {
       this.$router.push(`/alat-kesehatan/detail/${data.id}`)
@@ -430,6 +472,15 @@ export default {
         kemendagri_kabupaten_nama: this.district_name
       }
       this.listQuery.city_code = this.districtCity.kemendagri_kabupaten_kode
+    },
+    filterQuery(oldQuery) {
+      const newQuery = { ...oldQuery }
+      Object.keys(newQuery).forEach(key => {
+        if (newQuery[key] === null || newQuery[key] === undefined || newQuery[key] === '' || key === 'approval_status' || key === 'is_rejected') {
+          delete newQuery[key]
+        }
+      })
+      return newQuery
     }
   }
 }

--- a/src/views/pengajuanLogistik/list.vue
+++ b/src/views/pengajuanLogistik/list.vue
@@ -52,7 +52,8 @@
           <v-col cols="12" sm="3">
             <v-label class="title">{{ $t('label.request_date') }}</v-label>
             <date-picker-dashboard
-              :date="listQuery.start_date"
+              :initial-start-date="listQuery.start_date"
+              :initial-end-date="listQuery.end_date"
               @selected="changeDate"
             />
           </v-col>

--- a/src/views/pengajuanLogistik/list.vue
+++ b/src/views/pengajuanLogistik/list.vue
@@ -477,7 +477,7 @@ export default {
     filterQuery(oldQuery) {
       const newQuery = { ...oldQuery }
       Object.keys(newQuery).forEach(key => {
-        if (newQuery[key] === null || newQuery[key] === undefined || newQuery[key] === '' || key === 'approval_status' || key === 'is_rejected') {
+        if (newQuery[key] === null || newQuery[key] === undefined || newQuery[key] === '' || key === 'approval_status' || key === 'is_rejected' || key === 'verification_status') {
           delete newQuery[key]
         }
       })

--- a/src/views/tracking/index.vue
+++ b/src/views/tracking/index.vue
@@ -68,7 +68,7 @@
         </div>
         <div class="form mt-10" :class="{ 'item-header': $vuetify.breakpoint.lgAndUp }">
           <ValidationObserver ref="observer">
-            <v-form ref="form" @submit="getDataTracking(1)">
+            <div ref="form" @submit="getDataTracking(1)">
               <v-label>
                 <b>{{ $t('label.tracking_search') }}</b>
                 <i class="text-small-first-step">{{ $t('label.must_fill') }}</i>
@@ -116,7 +116,7 @@
                   {{ $t('label.track_now') }}
                 </v-btn>
               </div>
-            </v-form>
+            </div>
           </ValidationObserver>
         </div>
       </v-card>


### PR DESCRIPTION
### Problem Statement
The filter and pagination on logistic request page were always reset, after user going back from detail page
### PR Description
1. Add filter & pagination param into router query (solve main problem)
2. Add `initial-start-date` and `initial-end-date` prop to `date-picker-dashboard` component
3. Fix auto reload tracking form (additional fix)
### Task
https://trello.com/c/jYR14PEu/437-permohonan-ketika-sudah-membuka-detail-permohonan-seharusnya-kembali-ke-pagination-halaman-yang-telah-dipilih